### PR TITLE
Fix link about page

### DIFF
--- a/_tools/fractal.md
+++ b/_tools/fractal.md
@@ -7,6 +7,7 @@ description: Fractal is a tool to help you build and document web component libr
 tags:
 - frameworks
 - development
+- documentation
 
 # ================================
 # TOOLS CATEGORIES AVAILABLE

--- a/about.html
+++ b/about.html
@@ -11,7 +11,7 @@ description: About Design Systems Repo
             <div class="post-head-wrap">
               <div class="post-head-content">
                 <h1 class="post-title">{{ page.title | escape }}</h1>
-                <p>When I joined the <a href="https://designsystems.quickbooks.com/" title="QuickBooks Design System">QuickBooks Design System</a> team last year, I started collecting resources for my personal reference. I've gone back and browsed my collection of sites, articles and tools countless times since then. I decided to organize and catalog these resources into a site so it can be of help to others in the design community.</p>
+                <p>When I joined the <a href="https://designsystem.quickbooks.com/" title="QuickBooks Design System">QuickBooks Design System</a> team last year, I started collecting resources for my personal reference. I've gone back and browsed my collection of sites, articles and tools countless times since then. I decided to organize and catalog these resources into a site so it can be of help to others in the design community.</p>
               </div>
               <img class="illustration" src="{{ site.baseurl }}/images/dsr-logo-blocks.svg" width="120" height="122" alt="Design Systems Repo" />
             </div>


### PR DESCRIPTION
This PR fixes the link to QuickBooks in the about page and adds the documentation tag to Fractal.