### PR TITLE
fix: update primer url

### DIFF
--- a/content/design-systems/primer.md
+++ b/content/design-systems/primer.md
@@ -2,7 +2,7 @@
 date: 2018-06-12
 title: Primer
 company: GitHub
-link: https://styleguide.github.com/primer/
+link: https://primer.style/
 image: /uploads/primer.jpg
 description: Resources, tooling, and design guidelines for building websites with Primer, GitHub's front-end framework.
 ---


### PR DESCRIPTION
Update primer link from https://styleguide.github.com/primer/ to https://primer.style/